### PR TITLE
리포트 관리 오류 수정

### DIFF
--- a/src/main/java/com/sharedOne/controller/report/lnhReportController.java
+++ b/src/main/java/com/sharedOne/controller/report/lnhReportController.java
@@ -68,8 +68,8 @@ public class lnhReportController {
 			@RequestParam(name="productCode", defaultValue="") String productCode,
 			@RequestParam(name="writer", defaultValue="") String writer,
 			@RequestParam(name="status", defaultValue="") String status,
-			@RequestParam(name="fromDate", defaultValue="") String fromDate,
-			@RequestParam(name="endDate", defaultValue="") String endDate,
+			@RequestParam(name="fromDate", defaultValue="0001-01-01") String fromDate,
+			@RequestParam(name="endDate", defaultValue="9999-12-31") String endDate,
 			Model model) {
 		
 		//검색 결과 리스트
@@ -137,8 +137,8 @@ public class lnhReportController {
 			@RequestParam(name="productCode", defaultValue="") String productCode,
 			@RequestParam(name="writer", defaultValue="") String writer,
 			@RequestParam(name="status", defaultValue="") String status,
-			@RequestParam(name="fromDate", defaultValue="") String fromDate,
-			@RequestParam(name="endDate", defaultValue="") String endDate) throws IOException {
+			@RequestParam(name="fromDate", defaultValue="0001-01-01") String fromDate,
+			@RequestParam(name="endDate", defaultValue="9999-12-31") String endDate) throws IOException {
 		
 		
 		try (Workbook workbook = new XSSFWorkbook()) {


### PR DESCRIPTION
기간 검색 시 시작 기간만 조회하면 이전 날짜는 나오지 않게 하고 종료 기간만 조회하면 이후 날짜는 나오지 않게 수정함. 엑셀 다운로드도 똑같이 수정했습니다